### PR TITLE
feat: 관리자용 사용자 응답 조회 API 구현

### DIFF
--- a/src/main/kotlin/com/onsae/api/global/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/onsae/api/global/exception/GlobalExceptionHandler.kt
@@ -126,7 +126,8 @@ class GlobalExceptionHandler {
         CategoryNotFoundException::class,
         QuestionAssignmentNotFoundException::class,
         TemplateNotFoundException::class,
-        InvalidResponseDataException::class
+        InvalidResponseDataException::class,
+        ResponseNotFoundException::class
     )
     fun handleSurveyException(
         ex: BusinessException,

--- a/src/main/kotlin/com/onsae/api/survey/controller/QuestionResponseController.kt
+++ b/src/main/kotlin/com/onsae/api/survey/controller/QuestionResponseController.kt
@@ -1,0 +1,177 @@
+package com.onsae.api.survey.controller
+
+import com.onsae.api.auth.security.CustomUserPrincipal
+import com.onsae.api.survey.dto.AssignmentResponseSummaryDTO
+import com.onsae.api.survey.dto.QuestionResponseDetailDTO
+import com.onsae.api.survey.dto.UserResponseSummaryDTO
+import com.onsae.api.survey.service.QuestionResponseService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
+import mu.KotlinLogging
+import org.springframework.format.annotation.DateTimeFormat
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.Authentication
+import org.springframework.web.bind.annotation.*
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+private val logger = KotlinLogging.logger {}
+
+@RestController
+@RequestMapping("/api/responses")
+@Tag(name = "응답 조회", description = "관리자용 사용자 응답 조회 API")
+class QuestionResponseController(
+    private val questionResponseService: QuestionResponseService
+) {
+
+    @GetMapping("/user/{userId}")
+    @Operation(
+        summary = "사용자별 응답 조회",
+        description = "특정 사용자의 모든 응답을 조회합니다. 매일 반복 응답도 모두 포함됩니다."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "응답 조회 성공"),
+            ApiResponse(responseCode = "401", description = "인증 필요"),
+            ApiResponse(responseCode = "403", description = "권한 부족"),
+            ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
+        ]
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    fun getUserResponses(
+        @PathVariable userId: Long,
+        authentication: Authentication
+    ): ResponseEntity<UserResponseSummaryDTO> {
+        val principal = authentication.principal as CustomUserPrincipal
+
+        logger.info { "Fetching responses for user: $userId by admin: ${principal.userId}" }
+
+        val responses = questionResponseService.getUserResponses(userId, principal.institutionId!!)
+
+        return ResponseEntity.ok(responses)
+    }
+
+    @GetMapping("/assignment/{assignmentId}")
+    @Operation(
+        summary = "할당별 응답 조회",
+        description = "특정 질문 할당에 대한 모든 응답을 조회합니다. 같은 사용자의 매일 반복 응답도 모두 포함됩니다."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "응답 조회 성공"),
+            ApiResponse(responseCode = "401", description = "인증 필요"),
+            ApiResponse(responseCode = "403", description = "권한 부족"),
+            ApiResponse(responseCode = "404", description = "할당을 찾을 수 없음")
+        ]
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    fun getAssignmentResponses(
+        @PathVariable assignmentId: Long,
+        authentication: Authentication
+    ): ResponseEntity<AssignmentResponseSummaryDTO> {
+        val principal = authentication.principal as CustomUserPrincipal
+
+        logger.info { "Fetching responses for assignment: $assignmentId by admin: ${principal.userId}" }
+
+        val responses = questionResponseService.getAssignmentResponses(assignmentId, principal.institutionId!!)
+
+        return ResponseEntity.ok(responses)
+    }
+
+    @GetMapping("/user/{userId}/date-range")
+    @Operation(
+        summary = "사용자별 기간 응답 조회",
+        description = "특정 사용자의 특정 기간 내 응답을 조회합니다. 날짜별 응답 추이 확인에 유용합니다."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "응답 조회 성공"),
+            ApiResponse(responseCode = "401", description = "인증 필요"),
+            ApiResponse(responseCode = "403", description = "권한 부족"),
+            ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
+        ]
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    fun getUserResponsesByDateRange(
+        @PathVariable userId: Long,
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) startDate: LocalDateTime,
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) endDate: LocalDateTime,
+        authentication: Authentication
+    ): ResponseEntity<List<QuestionResponseDetailDTO>> {
+        val principal = authentication.principal as CustomUserPrincipal
+
+        logger.info { "Fetching responses for user: $userId between $startDate and $endDate" }
+
+        val responses = questionResponseService.getUserResponsesByDateRange(
+            userId,
+            principal.institutionId!!,
+            startDate,
+            endDate
+        )
+
+        return ResponseEntity.ok(responses)
+    }
+
+    @GetMapping("/recent")
+    @Operation(
+        summary = "최근 응답 조회",
+        description = "기관의 최근 응답을 조회합니다."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "응답 조회 성공"),
+            ApiResponse(responseCode = "401", description = "인증 필요"),
+            ApiResponse(responseCode = "403", description = "권한 부족")
+        ]
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    fun getRecentResponses(
+        @RequestParam(defaultValue = "20") limit: Int,
+        authentication: Authentication
+    ): ResponseEntity<List<QuestionResponseDetailDTO>> {
+        val principal = authentication.principal as CustomUserPrincipal
+
+        logger.info { "Fetching recent $limit responses for institution: ${principal.institutionId}" }
+
+        val responses = questionResponseService.getRecentResponses(principal.institutionId!!, limit)
+
+        return ResponseEntity.ok(responses)
+    }
+
+    @GetMapping("/question/{questionId}/user/{userId}/history")
+    @Operation(
+        summary = "질문별 사용자 응답 이력 조회",
+        description = "특정 날짜에 특정 사용자가 특정 질문에 답변한 모든 이력을 조회합니다. 같은 날 여러 번 수정한 경우 모든 이력이 포함됩니다."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "응답 이력 조회 성공"),
+            ApiResponse(responseCode = "401", description = "인증 필요"),
+            ApiResponse(responseCode = "403", description = "권한 부족"),
+            ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
+        ]
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    fun getQuestionResponseHistory(
+        @PathVariable questionId: Long,
+        @PathVariable userId: Long,
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate,
+        authentication: Authentication
+    ): ResponseEntity<List<QuestionResponseDetailDTO>> {
+        val principal = authentication.principal as CustomUserPrincipal
+
+        logger.info { "Fetching response history for question: $questionId, user: $userId, date: $date" }
+
+        val responses = questionResponseService.getQuestionResponseHistory(
+            questionId,
+            userId,
+            date,
+            principal.institutionId!!
+        )
+
+        return ResponseEntity.ok(responses)
+    }
+}

--- a/src/main/kotlin/com/onsae/api/survey/dto/QuestionResponseDetailDTO.kt
+++ b/src/main/kotlin/com/onsae/api/survey/dto/QuestionResponseDetailDTO.kt
@@ -1,0 +1,42 @@
+package com.onsae.api.survey.dto
+
+import com.onsae.api.survey.entity.QuestionType
+import java.time.LocalDateTime
+
+data class QuestionResponseDetailDTO(
+    val responseId: Long,
+    val assignmentId: Long,
+    val questionId: Long,
+    val questionTitle: String,
+    val questionContent: String,
+    val questionType: QuestionType,
+    val userId: Long,
+    val userName: String,
+    val responseData: Map<String, Any>,
+    val responseText: String?,
+    val otherResponse: String?,
+    val responseTimeSeconds: Int?,
+    val submittedAt: LocalDateTime,
+    val ipAddress: String?,
+    val userAgent: String?,
+    val deviceInfo: Map<String, Any>?,
+    val isModified: Boolean,  // 같은 날 중복 답변이 있으면 true
+    val modificationCount: Int  // 같은 날 총 답변 횟수
+)
+
+data class UserResponseSummaryDTO(
+    val userId: Long,
+    val userName: String,
+    val totalResponses: Int,
+    val latestResponseAt: LocalDateTime?,
+    val responses: List<QuestionResponseDetailDTO>
+)
+
+data class AssignmentResponseSummaryDTO(
+    val assignmentId: Long,
+    val questionId: Long,
+    val questionTitle: String,
+    val questionType: QuestionType,
+    val totalResponses: Int,
+    val responses: List<QuestionResponseDetailDTO>
+)

--- a/src/main/kotlin/com/onsae/api/survey/exception/SurveyException.kt
+++ b/src/main/kotlin/com/onsae/api/survey/exception/SurveyException.kt
@@ -47,3 +47,8 @@ class TemplateAlreadyExistsException(
     message: String = "Template already exists",
     code: String = "TEMPLATE_ALREADY_EXISTS"
 ) : BusinessException(message, code, HttpStatus.CONFLICT)
+
+class ResponseNotFoundException(
+    message: String = "Response not found",
+    code: String = "RESPONSE_NOT_FOUND"
+) : BusinessException(message, code, HttpStatus.NOT_FOUND)

--- a/src/main/kotlin/com/onsae/api/survey/repository/QuestionResponseRepository.kt
+++ b/src/main/kotlin/com/onsae/api/survey/repository/QuestionResponseRepository.kt
@@ -72,4 +72,68 @@ interface QuestionResponseRepository : JpaRepository<QuestionResponse, Long> {
         AND qr.responseData IS NOT NULL
     """)
     fun countCompletedByGroupId(@Param("groupId") groupId: Long): Int
+
+    // Admin response queries
+    @Query("""
+        SELECT qr FROM QuestionResponse qr
+        LEFT JOIN FETCH qr.assignment a
+        LEFT JOIN FETCH qr.user u
+        LEFT JOIN FETCH qr.question q
+        WHERE u.id = :userId
+        AND u.institution.id = :institutionId
+        ORDER BY qr.submittedAt DESC
+    """)
+    fun findByUserIdAndInstitutionIdWithDetails(
+        @Param("userId") userId: Long,
+        @Param("institutionId") institutionId: Long
+    ): List<QuestionResponse>
+
+    @Query("""
+        SELECT qr FROM QuestionResponse qr
+        LEFT JOIN FETCH qr.assignment a
+        LEFT JOIN FETCH qr.user u
+        LEFT JOIN FETCH qr.question q
+        WHERE a.id = :assignmentId
+        AND a.institution.id = :institutionId
+        ORDER BY qr.submittedAt DESC
+    """)
+    fun findByAssignmentIdAndInstitutionIdWithDetails(
+        @Param("assignmentId") assignmentId: Long,
+        @Param("institutionId") institutionId: Long
+    ): List<QuestionResponse>
+
+    @Query("""
+        SELECT qr FROM QuestionResponse qr
+        LEFT JOIN FETCH qr.assignment a
+        LEFT JOIN FETCH qr.user u
+        LEFT JOIN FETCH qr.question q
+        WHERE u.id = :userId
+        AND u.institution.id = :institutionId
+        AND qr.submittedAt BETWEEN :startDate AND :endDate
+        ORDER BY qr.submittedAt DESC
+    """)
+    fun findByUserIdAndInstitutionIdAndDateRange(
+        @Param("userId") userId: Long,
+        @Param("institutionId") institutionId: Long,
+        @Param("startDate") startDate: LocalDateTime,
+        @Param("endDate") endDate: LocalDateTime
+    ): List<QuestionResponse>
+
+    @Query("""
+        SELECT qr FROM QuestionResponse qr
+        LEFT JOIN FETCH qr.assignment a
+        LEFT JOIN FETCH qr.user u
+        LEFT JOIN FETCH qr.question q
+        WHERE q.id = :questionId
+        AND u.id = :userId
+        AND u.institution.id = :institutionId
+        AND DATE(qr.submittedAt) = DATE(:date)
+        ORDER BY qr.submittedAt DESC
+    """)
+    fun findByQuestionIdAndUserIdAndDateWithDetails(
+        @Param("questionId") questionId: Long,
+        @Param("userId") userId: Long,
+        @Param("institutionId") institutionId: Long,
+        @Param("date") date: LocalDateTime
+    ): List<QuestionResponse>
 }

--- a/src/main/kotlin/com/onsae/api/survey/service/QuestionResponseService.kt
+++ b/src/main/kotlin/com/onsae/api/survey/service/QuestionResponseService.kt
@@ -1,0 +1,216 @@
+package com.onsae.api.survey.service
+
+import com.onsae.api.survey.dto.AssignmentResponseSummaryDTO
+import com.onsae.api.survey.dto.QuestionResponseDetailDTO
+import com.onsae.api.survey.dto.UserResponseSummaryDTO
+import com.onsae.api.survey.entity.QuestionResponse
+import com.onsae.api.survey.exception.QuestionAssignmentNotFoundException
+import com.onsae.api.survey.exception.QuestionNotFoundException
+import com.onsae.api.survey.repository.QuestionResponseRepository
+import com.onsae.api.user.exception.UserNotFoundException
+import com.onsae.api.user.repository.UserRepository
+import mu.KotlinLogging
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+private val logger = KotlinLogging.logger {}
+
+@Service
+@Transactional(readOnly = true)
+class QuestionResponseService(
+    private val questionResponseRepository: QuestionResponseRepository,
+    private val userRepository: UserRepository
+) {
+
+    /**
+     * 특정 사용자의 모든 응답 조회 (같은 날 중복 답변은 최신 것만 반환)
+     */
+    fun getUserResponses(userId: Long, institutionId: Long): UserResponseSummaryDTO {
+        logger.info { "Fetching responses for user: $userId in institution: $institutionId" }
+
+        // 사용자 확인
+        val user = userRepository.findByIdAndInstitutionId(userId, institutionId)
+            ?: throw UserNotFoundException("User not found: $userId")
+
+        val responses = questionResponseRepository.findByUserIdAndInstitutionIdWithDetails(userId, institutionId)
+        val responsesWithModificationInfo = addModificationInfoWithLatestOnly(responses)
+
+        return UserResponseSummaryDTO(
+            userId = user.id!!,
+            userName = user.name,
+            totalResponses = responsesWithModificationInfo.size,
+            latestResponseAt = responsesWithModificationInfo.maxOfOrNull { it.submittedAt },
+            responses = responsesWithModificationInfo
+        )
+    }
+
+    /**
+     * 특정 할당에 대한 모든 응답 조회 (같은 날 중복 답변은 최신 것만 반환)
+     */
+    fun getAssignmentResponses(assignmentId: Long, institutionId: Long): AssignmentResponseSummaryDTO {
+        logger.info { "Fetching responses for assignment: $assignmentId in institution: $institutionId" }
+
+        val responses = questionResponseRepository.findByAssignmentIdAndInstitutionIdWithDetails(assignmentId, institutionId)
+
+        if (responses.isEmpty()) {
+            throw QuestionAssignmentNotFoundException("Assignment not found or has no responses: $assignmentId")
+        }
+
+        val firstResponse = responses.first()
+        val question = firstResponse.question ?: throw QuestionNotFoundException("Question not found for assignment: $assignmentId")
+        val responsesWithModificationInfo = addModificationInfoWithLatestOnly(responses)
+
+        return AssignmentResponseSummaryDTO(
+            assignmentId = assignmentId,
+            questionId = question.id!!,
+            questionTitle = question.title,
+            questionType = question.questionType,
+            totalResponses = responsesWithModificationInfo.size,
+            responses = responsesWithModificationInfo
+        )
+    }
+
+    /**
+     * 사용자의 특정 기간 응답 조회 (같은 날 중복 답변은 최신 것만 반환)
+     */
+    fun getUserResponsesByDateRange(
+        userId: Long,
+        institutionId: Long,
+        startDate: LocalDateTime,
+        endDate: LocalDateTime
+    ): List<QuestionResponseDetailDTO> {
+        logger.info { "Fetching responses for user: $userId between $startDate and $endDate" }
+
+        // 사용자 확인
+        userRepository.findByIdAndInstitutionId(userId, institutionId)
+            ?: throw UserNotFoundException("User not found: $userId")
+
+        val responses = questionResponseRepository.findByUserIdAndInstitutionIdAndDateRange(
+            userId, institutionId, startDate, endDate
+        )
+
+        return addModificationInfoWithLatestOnly(responses)
+    }
+
+    /**
+     * 기관의 최근 응답 조회 (같은 날 중복 답변은 최신 것만 반환)
+     */
+    fun getRecentResponses(institutionId: Long, limit: Int): List<QuestionResponseDetailDTO> {
+        logger.info { "Fetching recent $limit responses for institution: $institutionId" }
+
+        val pageable = org.springframework.data.domain.PageRequest.of(0, limit)
+        val responses = questionResponseRepository.findRecentByInstitutionId(institutionId, pageable)
+
+        return addModificationInfoWithLatestOnly(responses)
+    }
+
+    /**
+     * 특정 질문, 사용자, 날짜의 응답 이력 조회
+     */
+    fun getQuestionResponseHistory(
+        questionId: Long,
+        userId: Long,
+        date: LocalDate,
+        institutionId: Long
+    ): List<QuestionResponseDetailDTO> {
+        logger.info { "Fetching response history for question: $questionId, user: $userId, date: $date" }
+
+        // 사용자 확인
+        userRepository.findByIdAndInstitutionId(userId, institutionId)
+            ?: throw UserNotFoundException("User not found: $userId")
+
+        val dateTime = date.atStartOfDay()
+        val responses = questionResponseRepository.findByQuestionIdAndUserIdAndDateWithDetails(
+            questionId, userId, institutionId, dateTime
+        )
+
+        return addModificationInfo(responses)
+    }
+
+    /**
+     * 응답 목록에 수정 정보 추가 (일반 조회용 - 같은 날짜/질문/사용자의 최신 답변만 반환)
+     */
+    private fun addModificationInfoWithLatestOnly(responses: List<QuestionResponse>): List<QuestionResponseDetailDTO> {
+        data class ResponseKey(val date: LocalDate, val questionId: Long, val userId: Long)
+
+        // (날짜, 질문ID, 사용자ID)별로 그룹핑
+        val groupedResponses = responses.groupBy { response ->
+            ResponseKey(
+                date = response.submittedAt.toLocalDate(),
+                questionId = response.question?.id ?: 0L,
+                userId = response.user?.id ?: 0L
+            )
+        }
+
+        // 각 그룹에서 가장 최근 답변만 선택
+        return groupedResponses.flatMap { (_, groupResponses) ->
+            val modificationCount = groupResponses.size
+            // submittedAt이 가장 최근인 것만 선택
+            val latestResponse = groupResponses.maxByOrNull { it.submittedAt }
+
+            if (latestResponse != null) {
+                listOf(latestResponse.toDetailDTO(modificationCount))
+            } else {
+                emptyList()
+            }
+        }.sortedByDescending { it.submittedAt }  // 최신순 정렬
+    }
+
+    /**
+     * 응답 목록에 수정 정보 추가 (이력 조회용 - 모든 답변 반환)
+     */
+    private fun addModificationInfo(responses: List<QuestionResponse>): List<QuestionResponseDetailDTO> {
+        // (날짜, 질문ID, 사용자ID)별로 응답 개수 카운트
+        data class ResponseKey(val date: LocalDate, val questionId: Long, val userId: Long)
+
+        val countMap = responses.groupBy { response ->
+            ResponseKey(
+                date = response.submittedAt.toLocalDate(),
+                questionId = response.question?.id ?: 0L,
+                userId = response.user?.id ?: 0L
+            )
+        }.mapValues { it.value.size }
+
+        return responses.map { response ->
+            val key = ResponseKey(
+                date = response.submittedAt.toLocalDate(),
+                questionId = response.question?.id ?: 0L,
+                userId = response.user?.id ?: 0L
+            )
+            val modificationCount = countMap[key] ?: 1
+            response.toDetailDTO(modificationCount)
+        }
+    }
+
+    /**
+     * Entity를 DTO로 변환
+     */
+    private fun QuestionResponse.toDetailDTO(modificationCount: Int): QuestionResponseDetailDTO {
+        val user = this.user ?: throw UserNotFoundException("User not found for response: ${this.id}")
+        val question = this.question ?: throw QuestionNotFoundException("Question not found for response: ${this.id}")
+        val assignment = this.assignment ?: throw QuestionAssignmentNotFoundException("Assignment not found for response: ${this.id}")
+
+        return QuestionResponseDetailDTO(
+            responseId = this.id!!,
+            assignmentId = assignment.id!!,
+            questionId = question.id!!,
+            questionTitle = question.title,
+            questionContent = question.content,
+            questionType = question.questionType,
+            userId = user.id!!,
+            userName = user.name,
+            responseData = this.responseData,
+            responseText = this.responseText,
+            otherResponse = this.otherResponse,
+            responseTimeSeconds = this.responseTimeSeconds,
+            submittedAt = this.submittedAt,
+            ipAddress = this.ipAddress?.hostAddress,
+            userAgent = this.userAgent,
+            deviceInfo = this.deviceInfo,
+            isModified = modificationCount > 1,
+            modificationCount = modificationCount
+        )
+    }
+}

--- a/src/main/kotlin/com/onsae/api/user/repository/UserRepository.kt
+++ b/src/main/kotlin/com/onsae/api/user/repository/UserRepository.kt
@@ -15,6 +15,7 @@ interface UserRepository : JpaRepository<User, Long> {
     fun existsByInstitutionIdAndUsercode(institutionId: Long, usercode: String): Boolean
     fun findByInstitutionId(institutionId: Long): List<User>
     fun findByInstitutionIdOrderByCreatedAtDesc(institutionId: Long): List<User>
+    fun findByIdAndInstitutionId(userId: Long, institutionId: Long): User?
 
     // Dashboard queries
     fun countByInstitutionId(institutionId: Long): Long


### PR DESCRIPTION
복지관 관리자가 사용자들의 질문 응답을 조회하고 관리할 수 있는
API를 추가했습니다. 매일 반복 답변 지원 및 같은 날 중복 수정 감지 기능을
포함합니다.

## 주요 기능

### 1. 응답 조회 API
- 사용자별 응답 조회: GET /api/responses/user/{userId}
- 질문 할당별 응답 조회: GET /api/responses/assignment/{assignmentId}
- 기간별 응답 조회: GET /api/responses/user/{userId}/date-range
- 최근 응답 조회: GET /api/responses/recent
- 응답 이력 조회: GET /api/responses/question/{questionId}/user/{userId}/history

### 2. 중복 답변 감지
- 같은 날짜에 같은 질문에 여러 번 답변한 경우 자동 감지
- isModified: 수정 여부 플래그
- modificationCount: 총 답변 횟수
- 일반 조회: 같은 날 최신 답변만 반환
- 이력 조회: 해당 날짜의 모든 답변 반환

### 3. 데이터 구조
- QuestionResponseDetailDTO: 응답 상세 정보
  - 질문 정보 (제목, 내용, 타입)
  - 사용자 정보 (ID, 이름)
  - 응답 데이터 (responseData, responseText, otherResponse)
  - 메타 정보 (제출 시간, IP, UserAgent, 응답 시간)
  - 수정 정보 (isModified, modificationCount)

## 기술 구현

### Repository
- QuestionResponseRepository에 기관별 권한 검증 쿼리 추가
- JOIN FETCH를 통한 N+1 쿼리 방지
- 날짜별 중복 답변 조회 쿼리 구현

### Service
- addModificationInfoWithLatestOnly(): 일반 조회용 (최신 답변만)
- addModificationInfo(): 이력 조회용 (모든 답변)
- 날짜/질문/사용자별 그룹핑 및 카운팅 로직

### Exception Handling
- ResponseNotFoundException 추가
- GlobalExceptionHandler에 예외 핸들러 등록
- UserRepository에 기관별 조회 메서드 추가

## 사용 예시

같은 날 3번 수정한 경우:
- 일반 조회: 15:00 최신 답변 1개 (isModified: true, count: 3)
- 이력 조회: 10:00, 12:00, 15:00 전체 3개 답변

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 설문 응답 데이터를 조회하는 새로운 관리자 전용 API 엔드포인트 추가
  * 사용자별 응답, 할당별 응답, 날짜 범위별 필터링, 최근 응답, 질문별 응답 이력 조회 기능 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->