### PR TITLE
feat: 질문 응답 기능 개선 및 관리자용 통계 API 추가

### DIFF
--- a/src/main/kotlin/com/onsae/api/survey/repository/QuestionResponseRepository.kt
+++ b/src/main/kotlin/com/onsae/api/survey/repository/QuestionResponseRepository.kt
@@ -14,6 +14,12 @@ interface QuestionResponseRepository : JpaRepository<QuestionResponse, Long> {
     fun findByAssignmentIdAndUserId(assignmentId: Long, userId: Long): QuestionResponse?
     fun findByAssignmentIdIn(assignmentIds: List<Long>): List<QuestionResponse>
 
+    fun findByAssignmentIdInAndSubmittedAtBetween(
+        assignmentIds: List<Long>,
+        startDate: LocalDateTime,
+        endDate: LocalDateTime
+    ): List<QuestionResponse>
+
     @Query("SELECT qr FROM QuestionResponse qr LEFT JOIN FETCH qr.assignment LEFT JOIN FETCH qr.user WHERE qr.assignment.id = :assignmentId")
     fun findByAssignmentIdWithDetails(assignmentId: Long): List<QuestionResponse>
 

--- a/src/main/kotlin/com/onsae/api/survey/service/UserQuestionService.kt
+++ b/src/main/kotlin/com/onsae/api/survey/service/UserQuestionService.kt
@@ -43,10 +43,15 @@ class UserQuestionService(
 
         val allAssignments = (directAssignments + groupAssignments).distinctBy { it.question?.id!! }
 
-        // 3. 응답 완료 여부 확인
+        // 3. 오늘 날짜 기준으로 응답 완료 여부 확인
+        val today = LocalDate.now()
+        val startOfDay = today.atStartOfDay()
+        val endOfDay = today.plusDays(1).atStartOfDay()
+
         val assignmentIds = allAssignments.map { it.id!! }
-        val completedResponses = questionResponseRepository.findByAssignmentIdIn(assignmentIds)
-            .associateBy { it.assignment?.id!! }
+        val completedResponses = questionResponseRepository.findByAssignmentIdInAndSubmittedAtBetween(
+            assignmentIds, startOfDay, endOfDay
+        ).associateBy { it.assignment?.id!! }
 
         // 4. UserQuestionResponse로 변환
         return allAssignments


### PR DESCRIPTION
- 관리자용 사용자별 질문 응답 통계 조회 API 추가 (GET /api/questions/statistics/{userId})
- 매일 같은 질문에 응답할 수 있도록 오늘 날짜 기준으로 응답 완료 여부 체크하도록 변경
- 이전에는 한 번 응답하면 영구적으로 완료 처리되었으나, 이제 매일 새롭게 질문을 받을 수 있음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 개별 사용자의 질문 통계를 조회할 수 있는 새로운 엔드포인트 추가됨

* **개선 사항**
  * 질문 통계 계산이 현재 날짜에 제출된 응답만 포함하도록 변경됨

<!-- end of auto-generated comment: release notes by coderabbit.ai -->