### PR TITLE
feat: prod/dev 환경에서 Swagger UI HTTP Basic Auth 보호 추가

### DIFF
--- a/src/main/kotlin/com/onsae/api/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/onsae/api/config/SecurityConfig.kt
@@ -1,14 +1,18 @@
 package com.onsae.api.config
 
 import com.onsae.api.auth.security.JwtAuthenticationFilter
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.core.userdetails.User
+import org.springframework.security.core.userdetails.UserDetailsService
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.security.provisioning.InMemoryUserDetailsManager
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 
@@ -19,16 +23,43 @@ class SecurityConfig(
     private val jwtAuthenticationFilter: JwtAuthenticationFilter
 ) {
 
+    @Value("\${app.swagger.security.enabled:false}")
+    private var swaggerSecurityEnabled: Boolean = false
+
+    @Value("\${app.swagger.security.username:admin}")
+    private lateinit var swaggerUsername: String
+
+    @Value("\${app.swagger.security.password:admin}")
+    private lateinit var swaggerPassword: String
+
     @Bean
     fun passwordEncoder(): PasswordEncoder = BCryptPasswordEncoder()
 
     @Bean
+    fun swaggerUserDetailsService(): UserDetailsService {
+        val user = User.builder()
+            .username(swaggerUsername)
+            .password(passwordEncoder().encode(swaggerPassword))
+            .roles("SWAGGER_USER")
+            .build()
+        return InMemoryUserDetailsManager(user)
+    }
+
+    @Bean
     fun filterChain(http: HttpSecurity): SecurityFilterChain {
-        return http
+        http
             .csrf { it.disable() }
             .formLogin { it.disable() }
-            .httpBasic { it.disable() }
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
+
+        // Swagger 보안 활성화 시 HTTP Basic Auth 사용
+        if (swaggerSecurityEnabled) {
+            http.httpBasic { }
+        } else {
+            http.httpBasic { it.disable() }
+        }
+
+        return http
             .authorizeHttpRequests { auth ->
                 auth
                     .requestMatchers("/actuator/**").permitAll()
@@ -52,7 +83,16 @@ class SecurityConfig(
                     .requestMatchers("/api/admin/approve/**").hasRole("SYSTEM_ADMIN")
                     .requestMatchers("/api/admin/**").hasAnyRole("ADMIN", "STAFF")
                     .requestMatchers("/api/test/**").permitAll()
-                    .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()
+                    // Swagger 경로는 환경에 따라 보호 여부 결정
+                    .apply {
+                        if (swaggerSecurityEnabled) {
+                            this.requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html")
+                                .hasRole("SWAGGER_USER")
+                        } else {
+                            this.requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html")
+                                .permitAll()
+                        }
+                    }
                     .requestMatchers("/api/user/**").hasRole("USER")
                     .anyRequest().authenticated()
             }

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -48,3 +48,7 @@ management:
 app:
   swagger:
     server-url: ${SWAGGER_SERVER_URL}
+    security:
+      enabled: true
+      username: ${SWAGGER_USERNAME:admin}
+      password: ${SWAGGER_PASSWORD:admin123!}

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -39,3 +39,5 @@ app:
     allowed-origins: http://localhost:3000,http://localhost:8081
   swagger:
     server-url: http://localhost:8080
+    security:
+      enabled: false

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -53,3 +53,7 @@ management:
 app:
   swagger:
     server-url: ${SWAGGER_SERVER_URL}
+    security:
+      enabled: true
+      username: ${SWAGGER_USERNAME}
+      password: ${SWAGGER_PASSWORD}


### PR DESCRIPTION
prod 및 dev 환경에서 Swagger 문서 접근 시 HTTP Basic Auth 인증을 요구하도록 설정하였습니다. local 환경에서는 개발 편의성을 위해 인증 없이 접근 가능합니다.

- SecurityConfig에 환경별 Swagger 보안 설정 추가
- HTTP Basic Auth를 통한 Swagger 접근 제어
- In-Memory 사용자 관리로 간단한 인증 구현
- application-local.yaml: 보안 비활성화
- application-dev.yaml: 보안 활성화 (기본값: admin/admin123!)
- application-prod.yaml: 보안 활성화 (환경변수 필수: SWAGGER_USERNAME, SWAGGER_PASSWORD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * API 문서 접근을 위한 환경 기반 보안 제어 추가
  * 선택적 사용자 인증을 통한 API 문서 보호 기능 제공
  * 기본 인증(HTTP Basic)을 조건부로 적용하여 보안 유연성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->